### PR TITLE
increase chunk size to delete rows

### DIFF
--- a/src/Resources/Sheet.php
+++ b/src/Resources/Sheet.php
@@ -39,7 +39,7 @@ class Sheet extends Resource
 
     public function dropAllRows()
     {
-        foreach (collect($this->get('rows'))->chunk(100) as $chunk) {
+        foreach (collect($this->get('rows'))->chunk(400) as $chunk) {
             $this->deleteRows(
                 $chunk
                     ->pluck('id')


### PR DESCRIPTION
Increasing chuck size to minimize time needed to delete all rows when high number of rows (current max limit of 20k).

There's currently no API options to delete all rows at once.